### PR TITLE
manually bump node to 21.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@types/eslint": "^8.44.7",
-        "@types/node": "^21.1.0",
+        "@types/node": "^20.9.0",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "@typescript-eslint/eslint-plugin": "^6.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@trpc/react-query": "^10.37.1",
         "@trpc/server": "^10.37.1",
         "next": "^14.0.1",
+        "node": "^21.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "superjson": "^2.2.0",
@@ -25,7 +26,7 @@
       },
       "devDependencies": {
         "@types/eslint": "^8.44.7",
-        "@types/node": "^20.9.0",
+        "@types/node": "^21.1.0",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
@@ -3289,6 +3290,26 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-21.1.0.tgz",
+      "integrity": "sha512-OQfrQdCuc+dAauWBA/QmmzGpIMzQz1RAj7f0AcWOXl/Tc9W5kv6JEJcR/cHH4ewj8rNWMbrcWAe5a0TIwDHuFw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-bin-setup": "^1.0.0"
+      },
+      "bin": {
+        "node": "bin/node"
+      },
+      "engines": {
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/node-bin-setup": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
+      "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg=="
     },
     "node_modules/node-releases": {
       "version": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@trpc/react-query": "^10.37.1",
     "@trpc/server": "^10.37.1",
     "next": "^14.0.1",
+    "node": "^21.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "superjson": "^2.2.0",
@@ -28,7 +29,7 @@
   },
   "devDependencies": {
     "@types/eslint": "^8.44.7",
-    "@types/node": "^20.9.0",
+    "@types/node": "^21.1.0",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/eslint": "^8.44.7",
-    "@types/node": "^21.1.0",
+    "@types/node": "^20.9.0",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.10.0",


### PR DESCRIPTION
dependabot isn't detecting node@latest for some reason, so i manually bumped node from 20.9.0 to 21.1.0. v20.x is now in LTS until october 2024, so it makes sense to update now.